### PR TITLE
Add PSI drift detection and multi-model comparison to PREDUN pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,47 @@ Set `version` to the desired period (e.g., `2024_2C` or `2025_1C`) and provide y
 
 After ingestion, execute the `refresh_canonical` job from the Dagster UI to update canonical tables.
 
+5. **Run the ML Pipeline (drift + training + scoring)**
+
+Use `full_cycle_job` to run drift detection, multi-model training and scoring in one shot.
+The training asset accepts two optional config parameters:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `train_sample_frac` | `0.15` | Fraction of training data to use. `0.15` ≈ dev mode (~2 min). `1.0` = full run (~40-50 min). |
+| `n_estimators` | `30` | Number of estimators for GBM and RandomForest. `30` = dev. `100` = full run. |
+
+**Dev run** (default — fast, for testing):
+
+```yaml
+ops:
+  train_student_dropout_model:
+    config:
+      train_sample_frac: 0.15
+      n_estimators: 30
+```
+
+**Full run** (for the final thesis results):
+
+```yaml
+ops:
+  train_student_dropout_model:
+    config:
+      train_sample_frac: 1.0
+      n_estimators: 100
+```
+
+If no config is provided, the dev defaults are used automatically.
+
+The job sequence for a new academic period is:
+
+```
+refresh_canonical  →  full_cycle_job
+```
+
+After `full_cycle_job` completes, the winning model is automatically tagged with
+`data_version`, `thesis_run`, and `staging_periods` in MLflow — no manual tagging needed.
+
 ## INDEC Data Pipeline Usage
 
 The `predun_indec` module implements a data pipeline to extract economic indicators from INDEC Argentina APIs and load them into PostgreSQL.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PREDUN: Predicting Student Dropout Rates at UNDAV Using MLOps
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Stable Release](https://img.shields.io/badge/development-v0.2.0-brightgreen.svg)](https://github.com/your-repo/releases)
+[![Stable Release](https://img.shields.io/badge/development-v0.3.0-brightgreen.svg)](https://github.com/your-repo/releases)
 
 PREDUN stands for "Predicción de Deserción Universitaria en UNDAV".
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ After ingestion, execute the `refresh_canonical` job from the Dagster UI to upda
 
 5. **Run the ML Pipeline (drift + training + scoring)**
 
-Use `full_cycle_job` to run drift detection, multi-model training and scoring in one shot.
+Use `drift_train_predict` to run drift detection, multi-model training and scoring in one shot.
 The training asset accepts two optional config parameters:
 
 | Parameter | Default | Description |
@@ -272,10 +272,10 @@ If no config is provided, the dev defaults are used automatically.
 The job sequence for a new academic period is:
 
 ```
-refresh_canonical  →  full_cycle_job
+refresh_canonical  →  drift_train_predict
 ```
 
-After `full_cycle_job` completes, the winning model is automatically tagged with
+After `drift_train_predict` completes, the winning model is automatically tagged with
 `data_version`, `thesis_run`, and `staging_periods` in MLflow — no manual tagging needed.
 
 ## INDEC Data Pipeline Usage

--- a/predun_dagster/predun_dagster/assets/__init__.py
+++ b/predun_dagster/predun_dagster/assets/__init__.py
@@ -1,5 +1,6 @@
 
 from .dbt_assets import dbt_project_assets
+from .drift_assets import detect_data_drift
 from .ml_assets import (
     train_student_dropout_model,
     predict_student_dropout_risk,
@@ -13,6 +14,7 @@ from .ingestion_assets import (
 
 __all__ = [
     "dbt_project_assets",
+    "detect_data_drift",
     "train_student_dropout_model",
     "predict_student_dropout_risk",
     "format_history_data",

--- a/predun_dagster/predun_dagster/assets/drift_assets.py
+++ b/predun_dagster/predun_dagster/assets/drift_assets.py
@@ -30,9 +30,8 @@ from ..drift_utils import (
     drift_summary,
 )
 
-# Features derivadas que también deben analizarse (se calculan a partir del panel)
-DERIVED_FEATURES_NUM = ["promo_rate_period", "promo_rate_win3"]
-ALL_FEATURES_NUM = FEATURES_NUM + DERIVED_FEATURES_NUM
+# promo_rate_period y promo_rate_win3 ya están incluidas en FEATURES_NUM de drift_utils
+ALL_FEATURES_NUM = FEATURES_NUM
 
 DRIFT_EXPERIMENT = "drift_monitoring"
 

--- a/predun_dagster/predun_dagster/assets/drift_assets.py
+++ b/predun_dagster/predun_dagster/assets/drift_assets.py
@@ -1,0 +1,226 @@
+"""
+Asset Dagster de detección de drift para PREDUN.
+
+Compara la distribución de features del conjunto de entrenamiento (referencia fija,
+academic_period <= TRAIN_CUTOFF) contra los datos nuevos (post-cutoff), calculando
+PSI por feature. Los resultados se persisten en:
+
+  - MLflow  : métricas PSI por feature en experimento 'drift_monitoring'
+  - PostgreSQL : tabla predictions.drift_metrics (consumible por Superset)
+
+El nivel de drift global orienta la decisión MLOps:
+  none     → reentrenar rutinariamente con misma arquitectura
+  moderate → aumentar frecuencia de reentrenamiento, monitorear segmentos
+  high     → revisar features y evaluar arquitectura alternativa
+"""
+import os
+import time
+from datetime import datetime
+
+import mlflow
+import pandas as pd
+from dagster import AssetExecutionContext, asset
+from sqlalchemy import create_engine, text
+
+from ..drift_utils import (
+    TRAIN_CUTOFF,
+    FEATURES_NUM,
+    FEATURES_CAT,
+    compute_feature_drift,
+    drift_summary,
+)
+
+# Features derivadas que también deben analizarse (se calculan a partir del panel)
+DERIVED_FEATURES_NUM = ["promo_rate_period", "promo_rate_win3"]
+ALL_FEATURES_NUM = FEATURES_NUM + DERIVED_FEATURES_NUM
+
+DRIFT_EXPERIMENT = "drift_monitoring"
+
+CREATE_DRIFT_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS predictions.drift_metrics (
+    cycle_period      VARCHAR(20)  NOT NULL,
+    reference_period  VARCHAR(20)  NOT NULL,
+    feature_name      VARCHAR(100) NOT NULL,
+    feature_type      VARCHAR(20),
+    psi_value         FLOAT,
+    drift_level       VARCHAR(20),
+    mean_reference    FLOAT,
+    mean_current      FLOAT,
+    n_reference       INTEGER,
+    n_current         INTEGER,
+    computed_at       TIMESTAMP    DEFAULT NOW(),
+    PRIMARY KEY (cycle_period, reference_period, feature_name)
+)
+"""
+
+
+def _load_panel(engine) -> pd.DataFrame:
+    """Carga student_panel y calcula las features derivadas."""
+    NUM_COLS = [
+        "materias_en_periodo", "promo_en_periodo", "nota_media_en_periodo",
+        "materias_win3", "promo_win3", "nota_win3", "dias_desde_ult_periodo",
+    ]
+    df = pd.read_sql(
+        "SELECT * FROM marts.student_panel",
+        engine,
+    )
+    df = df.drop_duplicates()
+    df[NUM_COLS] = df[NUM_COLS].apply(pd.to_numeric, errors="coerce")
+    import numpy as np
+    df["promo_rate_period"] = df["promo_en_periodo"] / df["materias_en_periodo"].replace(0, np.nan)
+    df["promo_rate_win3"]   = df["promo_win3"]       / df["materias_win3"].replace(0, np.nan)
+    return df
+
+
+def _write_drift_to_db(engine, df_drift: pd.DataFrame, cycle_period: str, reference_period: str):
+    """Persiste resultados de drift en predictions.drift_metrics con upsert."""
+    with engine.connect() as conn:
+        conn.execute(text("CREATE SCHEMA IF NOT EXISTS predictions"))
+        conn.execute(text(CREATE_DRIFT_TABLE_SQL))
+        conn.commit()
+
+    rows = df_drift.copy()
+    rows["cycle_period"]     = cycle_period
+    rows["reference_period"] = reference_period
+    rows["computed_at"]      = datetime.utcnow()
+
+    # Upsert: eliminar registros anteriores del mismo ciclo/referencia antes de insertar
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "DELETE FROM predictions.drift_metrics "
+                "WHERE cycle_period = :cp AND reference_period = :rp"
+            ),
+            {"cp": cycle_period, "rp": reference_period},
+        )
+        conn.commit()
+
+    rows.to_sql(
+        "drift_metrics",
+        engine,
+        schema="predictions",
+        if_exists="append",
+        index=False,
+        method="multi",
+    )
+
+
+@asset(
+    required_resource_keys={"mlflow_monitoring"},
+    deps=["dbt_project_assets"],
+    description=(
+        "Detecta drift entre el conjunto de entrenamiento (referencia) y los datos "
+        "nuevos usando PSI. Registra métricas en MLflow y en predictions.drift_metrics."
+    ),
+)
+def detect_data_drift(context: AssetExecutionContext) -> dict:
+    """
+    Calcula PSI por feature comparando:
+      - Referencia : student_panel donde academic_period <= TRAIN_CUTOFF (2022_2C)
+      - Actual     : student_panel donde academic_period >  TRAIN_CUTOFF
+
+    La comparación referencia-vs-actual responde la pregunta operacional clave:
+    '¿la población que estamos scorando hoy difiere de la que entrenamos el modelo?'
+    """
+    pg_uri = os.getenv("PG_URI", "postgresql://siu:siu@localhost:5432/postgres")
+    engine = create_engine(pg_uri)
+
+    # ── 1. Cargar datos ───────────────────────────────────────────────────────
+    context.log.info("Cargando student_panel para análisis de drift...")
+    start_load = time.time()
+    df = _load_panel(engine)
+    context.log.info(f"Panel cargado: {len(df):,} filas en {time.time()-start_load:.1f}s")
+
+    ref_mask = df["academic_period"] <= TRAIN_CUTOFF
+    cur_mask = df["academic_period"] >  TRAIN_CUTOFF
+
+    df_ref = df[ref_mask].copy()
+    df_cur = df[cur_mask].copy()
+
+    cycle_period     = str(df_cur["academic_period"].max())  # período más reciente disponible
+    reference_period = TRAIN_CUTOFF
+
+    context.log.info(
+        f"Referencia: {len(df_ref):,} filas (hasta {reference_period}) | "
+        f"Actual: {len(df_cur):,} filas (desde {TRAIN_CUTOFF} hasta {cycle_period})"
+    )
+
+    # ── 2. Calcular PSI ───────────────────────────────────────────────────────
+    context.log.info("Calculando PSI por feature...")
+    df_drift = compute_feature_drift(
+        df_reference=df_ref,
+        df_current=df_cur,
+        features_num=ALL_FEATURES_NUM,
+        features_cat=FEATURES_CAT,
+        include_label=True,
+    )
+
+    summary = drift_summary(df_drift)
+    context.log.info(
+        f"Drift global: {summary['overall_level'].upper()} "
+        f"(max PSI={summary['max_psi']:.4f}, "
+        f"high={summary['n_features_high']}, "
+        f"moderate={summary['n_features_mod']}, "
+        f"none={summary['n_features_none']})"
+    )
+
+    # Log por feature al contexto de Dagster
+    for _, row in df_drift.iterrows():
+        context.log.info(
+            f"  PSI {row['feature_name']:<30} = {row['psi_value']:.4f}  [{row['drift_level']}]"
+        )
+
+    # ── 3. Registrar en MLflow ────────────────────────────────────────────────
+    with context.resources.mlflow_monitoring.track_job(
+        job_name="detect_data_drift",
+        tags={
+            "cycle_period":     cycle_period,
+            "reference_period": reference_period,
+            "drift_level":      summary["overall_level"],
+        },
+    ):
+        # Métricas PSI por feature
+        for _, row in df_drift.iterrows():
+            safe_name = row["feature_name"].replace(" ", "_")
+            mlflow.log_metric(f"psi_{safe_name}", row["psi_value"])
+
+        # Métricas de resumen
+        mlflow.log_metric("psi_max",             summary["max_psi"])
+        mlflow.log_metric("n_features_high_drift",   summary["n_features_high"])
+        mlflow.log_metric("n_features_mod_drift",    summary["n_features_mod"])
+        mlflow.log_metric("n_reference",         len(df_ref))
+        mlflow.log_metric("n_current",           len(df_cur))
+
+        # Guardar tabla de drift como artefacto CSV
+        import tempfile, json
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, prefix="drift_report_"
+        ) as f:
+            df_drift.to_csv(f.name, index=False)
+            csv_path = f.name
+        mlflow.log_artifact(csv_path, "drift_artifacts")
+
+        # Guardar summary como artefacto JSON
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, prefix="drift_summary_"
+        ) as f:
+            json.dump({**summary, "cycle_period": cycle_period, "reference_period": reference_period}, f, indent=2)
+            json_path = f.name
+        mlflow.log_artifact(json_path, "drift_artifacts")
+
+    # ── 4. Persistir en PostgreSQL para Superset ──────────────────────────────
+    context.log.info("Guardando resultados en predictions.drift_metrics...")
+    _write_drift_to_db(engine, df_drift, cycle_period, reference_period)
+    context.log.info(f"Guardados {len(df_drift)} registros de drift en PostgreSQL")
+
+    return {
+        "cycle_period":      cycle_period,
+        "reference_period":  reference_period,
+        "overall_drift":     summary["overall_level"],
+        "max_psi":           summary["max_psi"],
+        "n_features_high":   summary["n_features_high"],
+        "n_features_mod":    summary["n_features_mod"],
+        "top3_features":     summary["top3_features"],
+        "n_reference":       len(df_ref),
+        "n_current":         len(df_cur),
+    }

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -1,297 +1,46 @@
+"""
+Assets de entrenamiento y scoring para PREDUN.
+
+Cambios respecto a la versión original:
+  - train_student_dropout_model entrena 3 modelos candidatos en paralelo:
+      GradientBoostingClassifier (baseline original)
+      RandomForestClassifier     (ensemble paralelo, más rápido)
+      LogisticRegression         (baseline lineal, máxima interpretabilidad)
+  - El mejor modelo por AUC se registra en el MLflow Model Registry.
+  - Cada candidato queda trazado como run independiente en MLflow con
+    el tag model_candidate=True, permitiendo comparar en la UI.
+  - Los resultados de la competencia se persisten en
+    predictions.model_evaluations para consumo en Superset.
+  - predict_student_dropout_risk no cambia: carga el mejor modelo del
+    Registry y genera predicciones como antes.
+"""
 import os
 import shutil
 import time
-import numpy as np
-import pandas as pd
-import joblib
-import mlflow
-import mlflow.sklearn
-from sqlalchemy import create_engine
-from sklearn.pipeline import Pipeline
-from sklearn.compose import ColumnTransformer
-from sklearn.impute import SimpleImputer
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
-from sklearn.ensemble import GradientBoostingClassifier
-from sklearn.metrics import classification_report, roc_auc_score
-from dagster import asset, AssetExecutionContext
 import subprocess
+import tempfile
+import json
 import logging
+
+from dagster import asset, AssetExecutionContext
 
 
 def _conda_bin() -> str:
-    """Resolve conda executable from env or PATH, avoids hardcoded absolute paths."""
     return os.environ.get("CONDA_EXE") or shutil.which("conda") or "conda"
 
 
-def run_model_in_conda_env(context: AssetExecutionContext):
-    """Run model training in the eda-predun conda environment"""
-    # Get environment variables for database connection
-    pg_uri = os.getenv("PG_URI", "postgresql://user:password@localhost:5432/postgres")
-    
-    # Script content to run the model
-    model_script = f'''
-import os
-import time
-import numpy as np
-import pandas as pd
-import joblib
-import mlflow
-import mlflow.sklearn
-from sqlalchemy import create_engine
-from sklearn.pipeline import Pipeline
-from sklearn.compose import ColumnTransformer
-from sklearn.impute import SimpleImputer
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
-from sklearn.ensemble import GradientBoostingClassifier
-from sklearn.metrics import classification_report, roc_auc_score
+# ── Script de entrenamiento multi-modelo ──────────────────────────────────────
 
-# Setup MLflow
-mlflow.set_tracking_uri("http://localhost:8002")
-mlflow.set_experiment("student_dropout_prediction")
-
-# Database connection
-PG_URI = "{pg_uri}"
-engine = create_engine(PG_URI)
-
-# Read data from PostgreSQL
-df = pd.read_sql("SELECT * FROM marts.student_panel", engine)
-
-# Data preprocessing - same as sample_model.py
-df = df.drop_duplicates()
-
-# Convert numeric columns
-num_cols = [
-    'materias_en_periodo', 'promo_en_periodo', 'nota_media_en_periodo',
-    'materias_win3', 'promo_win3', 'nota_win3', 'dias_desde_ult_periodo'
-]
-
-df[num_cols] = df[num_cols].apply(pd.to_numeric, errors='coerce')
-
-# Verify target is binary
-assert df['dropout_next'].isin([0, 1]).all(), "Unexpected values in dropout_next"
-
-# Feature engineering
-df['promo_rate_period'] = df['promo_en_periodo'] / df['materias_en_periodo'].replace(0, np.nan)
-df['promo_rate_win3'] = df['promo_win3'] / df['materias_win3'].replace(0, np.nan)
-
-# Cumulative subjects
-df['materias_cum'] = (
-    df.sort_values('academic_period')
-      .groupby(['legajo', 'cod_carrera'])['materias_en_periodo']
-      .cumsum()
-)
-
-# Feature columns
-feature_cols_num = num_cols + ['promo_rate_period', 'promo_rate_win3', 'materias_cum']
-feature_cols_cat = ['cod_carrera']
-
-# Variables
-X = df[feature_cols_num + feature_cols_cat]
-y = df['dropout_next']
-
-# Time-based split (training until 2022_2C)
-train_mask = df['academic_period'] <= '2022_2C'
-X_train, y_train = X[train_mask], y[train_mask]
-X_val, y_val = X[~train_mask], y[~train_mask]
-
-print(f"Training: {{X_train.shape}}")
-print(f"Validation: {{X_val.shape}}")
-
-# Start MLflow run
-with mlflow.start_run(run_name="student_dropout_model_dagster_training") as run:
-    
-    # Log parameters
-    mlflow.log_param("train_size", X_train.shape[0])
-    mlflow.log_param("val_size", X_val.shape[0])
-    mlflow.log_param("num_features", len(feature_cols_num))
-    mlflow.log_param("cat_features", len(feature_cols_cat))
-    mlflow.log_param("train_period_cutoff", "2022_2C")
-    
-    # Preprocessing pipelines
-    numeric_pipe = Pipeline([
-        ("imputer", SimpleImputer(strategy="median")),
-        ("scaler", StandardScaler())
-    ])
-
-    categorical_pipe = Pipeline([
-        ("imputer", SimpleImputer(strategy="most_frequent")),
-        ("encoder", OneHotEncoder(handle_unknown="ignore"))
-    ])
-
-    # Composition
-    preprocess = ColumnTransformer([
-        ("num", numeric_pipe, feature_cols_num),
-        ("cat", categorical_pipe, feature_cols_cat)
-    ])
-
-    # Classifier
-    clf = GradientBoostingClassifier(random_state=42)
-
-    # Complete pipeline
-    pipeline = Pipeline([
-        ("prep", preprocess),
-        ("model", clf)
-    ])
-    
-    # Log model parameters
-    mlflow.log_param("imputer_strategy_num", "median")
-    mlflow.log_param("imputer_strategy_cat", "most_frequent")
-    mlflow.log_param("scaler", "StandardScaler")
-    mlflow.log_param("encoder", "OneHotEncoder")
-    mlflow.log_param("classifier", "GradientBoostingClassifier")
-    mlflow.log_param("random_state", 42)
-    
-    # Training
-    start_time = time.time()
-    pipeline.fit(X_train, y_train)
-    training_time = time.time() - start_time
-    
-    mlflow.log_metric("training_time_seconds", training_time)
-    
-    # Predictions
-    preds = pipeline.predict(X_val)
-    proba = pipeline.predict_proba(X_val)[:, 1]
-    
-    # Metrics
-    roc_auc = roc_auc_score(y_val, proba)
-    
-    mlflow.log_metric("roc_auc", roc_auc)
-    mlflow.log_metric("validation_accuracy", (preds == y_val).mean())
-    mlflow.log_metric("positive_class_rate", y_val.mean())
-    mlflow.log_metric("predicted_positive_rate", preds.mean())
-    
-    # Log classification report as text
-    class_report = classification_report(y_val, preds, digits=3)
-    print("Classification report:")
-    print(class_report)
-    
-    # Save classification report as artifact
-    with open("classification_report.txt", "w") as f:
-        f.write(class_report)
-    mlflow.log_artifact("classification_report.txt")
-    
-    # Log model
-    mlflow.sklearn.log_model(
-        sk_model=pipeline,
-        artifact_path="model",
-        registered_model_name="student_dropout_model"
-    )
-    
-    print(f"ROC-AUC: {{roc_auc:.3f}}")
-    print(f"Training completed in {{training_time:.2f}} seconds")
-    print(f"MLflow run ID: {{run.info.run_id}}")
-    
-    # Return metrics for Dagster
-    import json
-    result = {{
-        "roc_auc": roc_auc,
-        "training_time": training_time,
-        "train_size": X_train.shape[0],
-        "val_size": X_val.shape[0],
-        "run_id": run.info.run_id
-    }}
-    
-    print("DAGSTER_RESULT:" + json.dumps(result))
-'''
-
-    # Write script to temporary file
-    import tempfile
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
-        f.write(model_script)
-        script_path = f.name
-    
-    try:
-        # Run the script in the eda-predun conda environment
-        context.log.info("Starting model training in eda-predun conda environment")
-        start_time = time.time()
-        
-        cmd = [
-            _conda_bin(), "run", "-n", "eda-predun",
-            "python", script_path
-        ]
-        
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        duration = time.time() - start_time
-        
-        context.log.info(f"Model training completed in {duration:.2f} seconds")
-        context.log.info("Training output:")
-        context.log.info(result.stdout)
-        
-        # Extract result from output
-        import json
-        lines = result.stdout.strip().split('\n')
-        for line in lines:
-            if line.startswith("DAGSTER_RESULT:"):
-                result_data = json.loads(line.replace("DAGSTER_RESULT:", ""))
-                context.log.info(f"Training metrics: {result_data}")
-                return result_data
-        
-        # If no result found, return basic info
-        return {"status": "completed", "duration": duration}
-        
-    except subprocess.CalledProcessError as e:
-        context.log.error(f"Error running model training: {e.stderr}")
-        raise
-    finally:
-        # Clean up temporary file
-        if os.path.exists(script_path):
-            os.unlink(script_path)
-
-
-@asset(
-    required_resource_keys={"mlflow_monitoring"},
-    deps=["dbt_project_assets"]  # Depends on DBT assets to ensure marts.student_panel exists
-)
-def train_student_dropout_model(context: AssetExecutionContext):
+def run_multi_model_training_in_conda_env(context: AssetExecutionContext) -> dict:
     """
-    Train a student dropout prediction model using data from marts.student_panel.
-    
-    This asset:
-    - Runs in the 'eda-predun' conda environment
-    - Reads data from PostgreSQL marts.student_panel table
-    - Trains a GradientBoostingClassifier with preprocessing pipeline
-    - Logs metrics and model to MLflow running on port 8002
-    - Does not save results to CSV files
-    
-    Returns training metrics and MLflow run information.
+    Ejecuta el entrenamiento de los 3 modelos candidatos en el entorno eda-predun.
+
+    Retorna un dict con el nombre del modelo ganador, su AUC y el run_id de MLflow.
     """
-    
-    # Track the job with MLFlow monitoring
-    with context.resources.mlflow_monitoring.track_job(
-        job_name="train_student_dropout_model",
-        tags={"model_type": "GradientBoostingClassifier", "environment": "eda-predun"}
-    ):
-        context.log.info("Starting student dropout model training")
-        
-        # Run the model training in conda environment
-        result = run_model_in_conda_env(context)
-        
-        # Log additional metrics to the MLFlow monitoring resource
-        if "roc_auc" in result:
-            context.resources.mlflow_monitoring.log_process_metrics(
-                process_name="model_training",
-                start_time=time.time() - result.get("training_time", 0),
-                success=True,
-                additional_metrics={
-                    "model_roc_auc": result["roc_auc"],
-                    "training_samples": result.get("train_size", 0),
-                    "validation_samples": result.get("val_size", 0)
-                }
-            )
-        
-        context.log.info("Student dropout model training completed successfully")
-        return result
+    pg_uri = os.getenv("PG_URI", "postgresql://siu:siu@localhost:5432/postgres")
 
-
-def run_prediction_in_conda_env(context: AssetExecutionContext):
-    """Run prediction in the eda-predun conda environment"""
-    # Get environment variables for database connection
-    pg_uri = os.getenv("PG_URI", "postgresql://user:password@localhost:5432/postgres")
-    
-    # Script content to run the prediction
-    prediction_script = f'''
-import os
-import time
+    training_script = f'''
+import os, time, json, warnings
 import numpy as np
 import pandas as pd
 import mlflow
@@ -301,255 +50,494 @@ from sklearn.pipeline import Pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
-from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    classification_report, roc_auc_score, brier_score_loss,
+    average_precision_score,
+)
+warnings.filterwarnings("ignore")
 
-# Setup MLflow
+# ── Configuración ──────────────────────────────────────────────────────────────
 mlflow.set_tracking_uri("http://localhost:8002")
 mlflow.set_experiment("student_dropout_prediction")
 
-# Database connection
+PG_URI = "{pg_uri}"
+engine = create_engine(PG_URI)
+TRAIN_CUTOFF = "2022_2C"
+
+NUM_COLS = [
+    "materias_en_periodo", "promo_en_periodo", "nota_media_en_periodo",
+    "materias_win3", "promo_win3", "nota_win3", "dias_desde_ult_periodo",
+]
+
+# ── Carga y preparación de datos ───────────────────────────────────────────────
+print("Cargando student_panel...")
+df = pd.read_sql("SELECT * FROM marts.student_panel", engine)
+df = df.drop_duplicates()
+df[NUM_COLS] = df[NUM_COLS].apply(pd.to_numeric, errors="coerce")
+assert df["dropout_next"].isin([0, 1]).all(), "Valores inesperados en dropout_next"
+
+df["promo_rate_period"] = df["promo_en_periodo"] / df["materias_en_periodo"].replace(0, np.nan)
+df["promo_rate_win3"]   = df["promo_win3"]       / df["materias_win3"].replace(0, np.nan)
+df["materias_cum"] = (
+    df.sort_values("academic_period")
+      .groupby(["legajo", "cod_carrera"])["materias_en_periodo"]
+      .cumsum()
+)
+
+FEATURE_COLS_NUM = NUM_COLS + ["promo_rate_period", "promo_rate_win3", "materias_cum"]
+FEATURE_COLS_CAT = ["cod_carrera"]
+
+X = df[FEATURE_COLS_NUM + FEATURE_COLS_CAT]
+y = df["dropout_next"]
+
+train_mask = df["academic_period"] <= TRAIN_CUTOFF
+X_train, y_train = X[train_mask], y[train_mask]
+X_val,   y_val   = X[~train_mask], y[~train_mask]
+
+print(f"Train: {{X_train.shape[0]:,}} | Val: {{X_val.shape[0]:,}}")
+
+# ── Preprocessing pipeline (compartido por todos los modelos) ──────────────────
+def build_pipeline(classifier):
+    numeric_pipe = Pipeline([
+        ("imputer", SimpleImputer(strategy="median")),
+        ("scaler",  StandardScaler()),
+    ])
+    categorical_pipe = Pipeline([
+        ("imputer", SimpleImputer(strategy="most_frequent")),
+        ("encoder", OneHotEncoder(handle_unknown="ignore")),
+    ])
+    preprocess = ColumnTransformer([
+        ("num", numeric_pipe,      FEATURE_COLS_NUM),
+        ("cat", categorical_pipe,  FEATURE_COLS_CAT),
+    ])
+    return Pipeline([("prep", preprocess), ("model", classifier)])
+
+# ── Modelos candidatos ─────────────────────────────────────────────────────────
+# Tres familias distintas: secuencial, paralelo, lineal.
+# Hiperparámetros por defecto + random_state para reproducibilidad.
+model_candidates = [
+    ("GradientBoosting",  GradientBoostingClassifier(random_state=42)),
+    ("RandomForest",      RandomForestClassifier(n_estimators=200, random_state=42, n_jobs=-1)),
+    ("LogisticRegression",LogisticRegression(max_iter=1000, random_state=42, n_jobs=-1)),
+]
+
+# ── Entrenamiento y evaluación de cada candidato ───────────────────────────────
+results = []
+client  = mlflow.tracking.MlflowClient()
+
+for model_name, clf in model_candidates:
+    print(f"\\nEntrenando {{model_name}}...")
+    t0 = time.time()
+
+    pipeline = build_pipeline(clf)
+
+    with mlflow.start_run(run_name=f"candidate_{{model_name}}_training") as run:
+        # Tags que identifican este run como candidato de esta comparación
+        mlflow.set_tag("model_candidate",  "true")
+        mlflow.set_tag("model_name",       model_name)
+        mlflow.set_tag("train_cutoff",     TRAIN_CUTOFF)
+
+        mlflow.log_param("classifier",            model_name)
+        mlflow.log_param("train_size",            X_train.shape[0])
+        mlflow.log_param("val_size",              X_val.shape[0])
+        mlflow.log_param("train_period_cutoff",   TRAIN_CUTOFF)
+        mlflow.log_param("num_features",          len(FEATURE_COLS_NUM))
+        mlflow.log_param("cat_features",          len(FEATURE_COLS_CAT))
+
+        pipeline.fit(X_train, y_train)
+        training_time = time.time() - t0
+
+        preds = pipeline.predict(X_val)
+        proba = pipeline.predict_proba(X_val)[:, 1]
+
+        roc_auc   = roc_auc_score(y_val, proba)
+        brier     = brier_score_loss(y_val, proba)
+        avg_prec  = average_precision_score(y_val, proba)
+        report    = classification_report(y_val, preds, digits=3, output_dict=True)
+        accuracy  = float((preds == y_val).mean())
+
+        # KS statistic
+        proba_pos = np.sort(proba[y_val == 1])
+        proba_neg = np.sort(proba[y_val == 0])
+        combined  = np.sort(np.concatenate([proba_pos, proba_neg]))
+        cdf_pos   = np.searchsorted(proba_pos, combined, side="right") / max(len(proba_pos), 1)
+        cdf_neg   = np.searchsorted(proba_neg, combined, side="right") / max(len(proba_neg), 1)
+        ks_stat   = float(np.max(np.abs(cdf_pos - cdf_neg)))
+
+        mlflow.log_metric("roc_auc",              roc_auc)
+        mlflow.log_metric("brier_score",          brier)
+        mlflow.log_metric("average_precision",    avg_prec)
+        mlflow.log_metric("ks_statistic",         ks_stat)
+        mlflow.log_metric("validation_accuracy",  accuracy)
+        mlflow.log_metric("training_time_seconds",training_time)
+        mlflow.log_metric("f1_dropout",           report["1"]["f1-score"])
+        mlflow.log_metric("precision_dropout",    report["1"]["precision"])
+        mlflow.log_metric("recall_dropout",       report["1"]["recall"])
+
+        # Guardar el modelo como artefacto (no registrar en Registry aún)
+        mlflow.sklearn.log_model(
+            sk_model=pipeline,
+            artifact_path="model",
+        )
+
+        results.append({{
+            "model_name":            model_name,
+            "run_id":                run.info.run_id,
+            "roc_auc":               roc_auc,
+            "brier_score":           brier,
+            "average_precision":     avg_prec,
+            "ks_statistic":          ks_stat,
+            "f1_dropout":            report["1"]["f1-score"],
+            "precision_dropout":     report["1"]["precision"],
+            "recall_dropout":        report["1"]["recall"],
+            "training_time_seconds": training_time,
+            "train_size":            X_train.shape[0],
+            "val_size":              X_val.shape[0],
+        }})
+
+        print(f"  {{model_name}}: AUC={{roc_auc:.4f}}  Brier={{brier:.4f}}  KS={{ks_stat:.4f}}  t={{training_time:.1f}}s")
+
+# ── Selección del mejor modelo ─────────────────────────────────────────────────
+best = max(results, key=lambda r: r["roc_auc"])
+print(f"\\nMejor modelo: {{best['model_name']}} (AUC={{best['roc_auc']:.4f}})")
+
+# Registrar SOLO el ganador en el Model Registry
+model_uri = f"runs:/{{best['run_id']}}/model"
+mv = mlflow.register_model(
+    model_uri=model_uri,
+    name="student_dropout_model",
+)
+mlflow.set_tag("winning_model", "true")  # tag adicional en el run ganador
+
+# Taggear el run ganador en MLflow para identificación visual
+with mlflow.start_run(run_id=best["run_id"]):
+    mlflow.set_tag("registered_in_registry", "true")
+    mlflow.set_tag("registry_version", mv.version)
+
+print(f"  Registrado como student_dropout_model v{{mv.version}}")
+
+# ── Persistir comparación en PostgreSQL ───────────────────────────────────────
+from datetime import datetime
+
+create_schema_sql = "CREATE SCHEMA IF NOT EXISTS predictions"
+create_table_sql  = """
+CREATE TABLE IF NOT EXISTS predictions.model_evaluations (
+    cycle_period              VARCHAR(20)  NOT NULL,
+    model_name                VARCHAR(100) NOT NULL,
+    mlflow_run_id             VARCHAR(100),
+    roc_auc                   FLOAT,
+    brier_score               FLOAT,
+    average_precision         FLOAT,
+    ks_statistic              FLOAT,
+    f1_dropout                FLOAT,
+    precision_dropout         FLOAT,
+    recall_dropout            FLOAT,
+    training_time_seconds     FLOAT,
+    train_size                INTEGER,
+    val_size                  INTEGER,
+    is_selected_model         BOOLEAN,
+    evaluated_at              TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (cycle_period, model_name)
+)
+"""
+
+# Usamos el período más reciente del panel como identificador del ciclo
+cycle_period = str(df["academic_period"].max())
+
+with engine.connect() as conn:
+    conn.execute(text(create_schema_sql))
+    conn.execute(text(create_table_sql))
+    # Limpiar evaluaciones previas del mismo ciclo para este run
+    conn.execute(
+        text("DELETE FROM predictions.model_evaluations WHERE cycle_period = :cp"),
+        {{"cp": cycle_period}},
+    )
+    conn.commit()
+
+rows = []
+for r in results:
+    rows.append({{
+        "cycle_period":           cycle_period,
+        "model_name":             r["model_name"],
+        "mlflow_run_id":          r["run_id"],
+        "roc_auc":                r["roc_auc"],
+        "brier_score":            r["brier_score"],
+        "average_precision":      r["average_precision"],
+        "ks_statistic":           r["ks_statistic"],
+        "f1_dropout":             r["f1_dropout"],
+        "precision_dropout":      r["precision_dropout"],
+        "recall_dropout":         r["recall_dropout"],
+        "training_time_seconds":  r["training_time_seconds"],
+        "train_size":             r["train_size"],
+        "val_size":               r["val_size"],
+        "is_selected_model":      (r["model_name"] == best["model_name"]),
+        "evaluated_at":           datetime.utcnow(),
+    }})
+
+pd.DataFrame(rows).to_sql(
+    "model_evaluations", engine, schema="predictions",
+    if_exists="append", index=False, method="multi",
+)
+print(f"Comparación guardada en predictions.model_evaluations (ciclo {{cycle_period}})")
+
+# ── Resultado para Dagster ─────────────────────────────────────────────────────
+output = {{
+    "best_model":       best["model_name"],
+    "roc_auc":          best["roc_auc"],
+    "brier_score":      best["brier_score"],
+    "ks_statistic":     best["ks_statistic"],
+    "run_id":           best["run_id"],
+    "registry_version": mv.version,
+    "cycle_period":     cycle_period,
+    "all_models":       [{{
+        "name": r["model_name"],
+        "roc_auc": round(r["roc_auc"], 4),
+        "brier":   round(r["brier_score"], 4),
+    }} for r in sorted(results, key=lambda x: x["roc_auc"], reverse=True)],
+}}
+print("DAGSTER_RESULT:" + json.dumps(output))
+'''
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(training_script)
+        script_path = f.name
+
+    try:
+        context.log.info("Iniciando entrenamiento multi-modelo en eda-predun...")
+        t0 = time.time()
+
+        result = subprocess.run(
+            [_conda_bin(), "run", "-n", "eda-predun", "python", script_path],
+            check=True, capture_output=True, text=True,
+        )
+        duration = time.time() - t0
+
+        context.log.info(f"Entrenamiento completado en {duration:.1f}s")
+        for line in result.stdout.splitlines():
+            context.log.info(line)
+
+        for line in result.stdout.strip().split("\n"):
+            if line.startswith("DAGSTER_RESULT:"):
+                return json.loads(line.replace("DAGSTER_RESULT:", ""))
+
+        return {"status": "completed", "duration": duration}
+
+    except subprocess.CalledProcessError as e:
+        context.log.error(f"Error en entrenamiento: {e.stderr}")
+        raise
+    finally:
+        if os.path.exists(script_path):
+            os.unlink(script_path)
+
+
+# ── Asset de entrenamiento ────────────────────────────────────────────────────
+
+@asset(
+    required_resource_keys={"mlflow_monitoring"},
+    deps=["dbt_project_assets"],
+)
+def train_student_dropout_model(context: AssetExecutionContext):
+    """
+    Entrena 3 modelos candidatos (GradientBoosting, RandomForest, LogisticRegression),
+    los evalúa sobre el mismo set de validación, registra el mejor en el MLflow
+    Model Registry y persiste la comparación en predictions.model_evaluations.
+    """
+    with context.resources.mlflow_monitoring.track_job(
+        job_name="train_student_dropout_model",
+        tags={"environment": "eda-predun", "mode": "multi_model"},
+    ):
+        context.log.info("Iniciando entrenamiento multi-modelo")
+        result = run_multi_model_training_in_conda_env(context)
+
+        if "roc_auc" in result:
+            context.resources.mlflow_monitoring.log_process_metrics(
+                process_name="model_training",
+                start_time=time.time() - result.get("training_time", 0),
+                success=True,
+                additional_metrics={
+                    "best_model_auc":     result["roc_auc"],
+                    "training_samples":   result.get("train_size", 0),
+                    "validation_samples": result.get("val_size", 0),
+                },
+            )
+        context.log.info(
+            f"Mejor modelo: {result.get('best_model', '?')} "
+            f"(AUC={result.get('roc_auc', '?')})"
+        )
+        return result
+
+
+# ── Script de scoring (sin cambios respecto al original) ──────────────────────
+
+def run_prediction_in_conda_env(context: AssetExecutionContext) -> dict:
+    """Genera predicciones en eda-predun usando el mejor modelo del MLflow Registry."""
+    pg_uri = os.getenv("PG_URI", "postgresql://siu:siu@localhost:5432/postgres")
+
+    prediction_script = f'''
+import os, time, json
+import numpy as np
+import pandas as pd
+import mlflow
+import mlflow.sklearn
+from sqlalchemy import create_engine, text
+
+mlflow.set_tracking_uri("http://localhost:8002")
+mlflow.set_experiment("student_dropout_prediction")
+
 PG_URI = "{pg_uri}"
 engine = create_engine(PG_URI)
 
-print("Loading latest model from MLflow...")
-
-# Get the latest model version from MLflow
+print("Cargando último modelo del Registry...")
 client = mlflow.tracking.MlflowClient()
 try:
-    latest_version = client.get_latest_versions("student_dropout_model", stages=["None"])
-    if not latest_version:
-        latest_version = client.get_latest_versions("student_dropout_model")
-    
-    if latest_version:
-        model_version = latest_version[0].version
-        model_uri = f"models:/student_dropout_model/{{model_version}}"
-        print(f"Loading model version {{model_version}}")
-        
-        # Load the model
-        model = mlflow.sklearn.load_model(model_uri)
-        print("Model loaded successfully")
-    else:
-        raise Exception("No trained model found in MLflow")
-        
+    latest = client.get_latest_versions("student_dropout_model", stages=["None"])
+    if not latest:
+        latest = client.get_latest_versions("student_dropout_model")
+    if not latest:
+        raise Exception("No hay modelo entrenado en el Registry")
+    model_version = latest[0].version
+    model = mlflow.sklearn.load_model(f"models:/student_dropout_model/{{model_version}}")
+    print(f"Modelo v{{model_version}} cargado OK")
 except Exception as e:
-    print(f"Error loading model: {{e}}")
+    print(f"Error cargando modelo: {{e}}")
     raise
 
-# Get active students from student_status
-print("Loading active students data...")
-query_students = """
-    SELECT DISTINCT legajo, 'estudiando' as status 
-    FROM marts.student_status 
-    WHERE status = 'estudiando'
-"""
-active_students = pd.read_sql(query_students, engine)
-print(f"Found {{len(active_students)}} active students")
-
+print("Cargando estudiantes activos...")
+active_students = pd.read_sql(
+    "SELECT DISTINCT legajo FROM marts.student_status WHERE status = \\'estudiando\\'",
+    engine,
+)
+print(f"{{len(active_students)}} estudiantes activos")
 if len(active_students) == 0:
-    print("No active students found - exiting")
+    print("Sin estudiantes activos — saliendo")
     exit(0)
 
-# Get student panel data for feature engineering - only for active students
-print("Loading student panel data for active students...")
-legajos_list = "', '".join(active_students['legajo'].astype(str))
-query_panel = f"""
-    SELECT * FROM marts.student_panel 
-    WHERE legajo IN ('{{legajos_list}}')
-    ORDER BY legajo, academic_period DESC
-"""
-student_panel = pd.read_sql(query_panel, engine)
-
+legajos_list = "\\', \\'".join(active_students["legajo"].astype(str))
+student_panel = pd.read_sql(
+    f"SELECT * FROM marts.student_panel WHERE legajo IN (\\\'{{legajos_list}}\\\') ORDER BY legajo, academic_period DESC",
+    engine,
+)
 if len(student_panel) == 0:
-    print("No student panel data found for active students - exiting")
+    print("Sin datos de panel para activos — saliendo")
     exit(0)
 
-print(f"Loaded {{len(student_panel)}} records from student panel")
+df = student_panel.groupby("legajo").first().reset_index()
+print(f"{{len(df)}} registros más recientes para scoring")
 
-# Get the most recent record for each student for prediction
-latest_records = student_panel.groupby('legajo').first().reset_index()
-print(f"Using {{len(latest_records)}} latest records for prediction")
-
-# Apply the same feature engineering as in training
-df = latest_records.copy()
-
-# Convert numeric columns (same as training)
-num_cols = [
-    'materias_en_periodo', 'promo_en_periodo', 'nota_media_en_periodo',
-    'materias_win3', 'promo_win3', 'nota_win3', 'dias_desde_ult_periodo'
+NUM_COLS = [
+    "materias_en_periodo", "promo_en_periodo", "nota_media_en_periodo",
+    "materias_win3", "promo_win3", "nota_win3", "dias_desde_ult_periodo",
 ]
+df[NUM_COLS] = df[NUM_COLS].apply(pd.to_numeric, errors="coerce")
+df["promo_rate_period"] = df["promo_en_periodo"] / df["materias_en_periodo"].replace(0, np.nan)
+df["promo_rate_win3"]   = df["promo_win3"]       / df["materias_win3"].replace(0, np.nan)
+df["materias_cum"]      = df["materias_en_periodo"].cumsum()
 
-df[num_cols] = df[num_cols].apply(pd.to_numeric, errors='coerce')
+FEATURE_COLS_NUM = NUM_COLS + ["promo_rate_period", "promo_rate_win3", "materias_cum"]
+FEATURE_COLS_CAT = ["cod_carrera"]
+X = df[FEATURE_COLS_NUM + FEATURE_COLS_CAT]
 
-# Feature engineering (same as training)
-df['promo_rate_period'] = df['promo_en_periodo'] / df['materias_en_periodo'].replace(0, np.nan)
-df['promo_rate_win3'] = df['promo_win3'] / df['materias_win3'].replace(0, np.nan)
+predictions  = model.predict(X)
+probabilities = model.predict_proba(X)[:, 1]
 
-# For cumulative subjects, use the value as-is since we're taking the latest record
-df['materias_cum'] = df['materias_en_periodo'].cumsum()
+print(f"Tasa de abandono predicha: {{predictions.mean():.3f}}")
 
-# Feature columns (same as training)
-feature_cols_num = num_cols + ['promo_rate_period', 'promo_rate_win3', 'materias_cum']
-feature_cols_cat = ['cod_carrera']
-
-# Prepare features for prediction
-X = df[feature_cols_num + feature_cols_cat]
-
-print("Making predictions...")
-# Get predictions and probabilities
-predictions = model.predict(X)
-probabilities = model.predict_proba(X)[:, 1]  # Probability of dropout
-
-print(f"Generated predictions for {{len(predictions)}} students")
-print(f"Predicted dropout rate: {{predictions.mean():.3f}}")
-print(f"Average dropout probability: {{probabilities.mean():.3f}}")
-
-# Prepare results dataframe
 results_df = pd.DataFrame({{
-    'legajo': df['legajo'],
-    'academic_period': df['academic_period'],
-    'cod_carrera': df['cod_carrera'],
-    'dropout_prediction': predictions,
-    'dropout_probability': probabilities,
-    'prediction_date': pd.Timestamp.now(),
-    'model_version': model_version
+    "legajo":               df["legajo"],
+    "academic_period":      df["academic_period"],
+    "cod_carrera":          df["cod_carrera"],
+    "dropout_prediction":   predictions,
+    "dropout_probability":  probabilities,
+    "prediction_date":      pd.Timestamp.now(),
+    "model_version":        model_version,
 }})
 
-# Create schema if it doesn't exist
 with engine.connect() as conn:
     conn.execute(text("CREATE SCHEMA IF NOT EXISTS predictions"))
+    conn.execute(text("""
+        CREATE TABLE IF NOT EXISTS predictions.student_dropout_predictions (
+            legajo               VARCHAR(50),
+            academic_period      VARCHAR(20),
+            cod_carrera          VARCHAR(20),
+            dropout_prediction   INTEGER,
+            dropout_probability  FLOAT,
+            prediction_date      TIMESTAMP,
+            model_version        VARCHAR(50),
+            PRIMARY KEY (legajo, prediction_date)
+        )"""))
     conn.commit()
 
-# Create table if it doesn't exist
-create_table_sql = """
-CREATE TABLE IF NOT EXISTS predictions.student_dropout_predictions (
-    legajo VARCHAR(50),
-    academic_period VARCHAR(20),
-    cod_carrera VARCHAR(20),
-    dropout_prediction INTEGER,
-    dropout_probability FLOAT,
-    prediction_date TIMESTAMP,
-    model_version VARCHAR(50),
-    PRIMARY KEY (legajo, prediction_date)
-)
-"""
-
-with engine.connect() as conn:
-    conn.execute(text(create_table_sql))
-    conn.commit()
-
-print("Saving predictions to database...")
-
-# Save to database
 results_df.to_sql(
-    'student_dropout_predictions', 
-    engine, 
-    schema='predictions',
-    if_exists='append', 
-    index=False,
-    method='multi'
+    "student_dropout_predictions", engine, schema="predictions",
+    if_exists="append", index=False, method="multi",
 )
+print(f"{{len(results_df)}} predicciones guardadas")
 
-print(f"Successfully saved {{len(results_df)}} predictions to predictions.student_dropout_predictions")
-
-# Return summary statistics
 summary = {{
-    "total_students": len(results_df),
-    "predicted_dropouts": int(predictions.sum()),
-    "dropout_rate": float(predictions.mean()),
+    "total_students":        len(results_df),
+    "predicted_dropouts":    int(predictions.sum()),
+    "dropout_rate":          float(predictions.mean()),
     "avg_dropout_probability": float(probabilities.mean()),
-    "model_version": model_version,
-    "prediction_date": pd.Timestamp.now().isoformat()
+    "model_version":         model_version,
+    "prediction_date":       pd.Timestamp.now().isoformat(),
 }}
-
-import json
 print("DAGSTER_RESULT:" + json.dumps(summary))
 '''
 
-    # Write script to temporary file
-    import tempfile
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
         f.write(prediction_script)
         script_path = f.name
-    
+
     try:
-        # Run the script in the eda-predun conda environment
-        context.log.info("Starting prediction generation in eda-predun conda environment")
-        start_time = time.time()
-        
-        cmd = [
-            _conda_bin(), "run", "-n", "eda-predun",
-            "python", script_path
-        ]
-        
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        duration = time.time() - start_time
-        
-        context.log.info(f"Prediction generation completed in {duration:.2f} seconds")
-        context.log.info("Prediction output:")
-        context.log.info(result.stdout)
-        
-        # Extract result from output
-        import json
-        lines = result.stdout.strip().split('\n')
-        for line in lines:
+        context.log.info("Generando predicciones en eda-predun...")
+        t0 = time.time()
+        result = subprocess.run(
+            [_conda_bin(), "run", "-n", "eda-predun", "python", script_path],
+            check=True, capture_output=True, text=True,
+        )
+        context.log.info(f"Scoring completado en {time.time()-t0:.1f}s")
+        for line in result.stdout.splitlines():
+            context.log.info(line)
+
+        for line in result.stdout.strip().split("\n"):
             if line.startswith("DAGSTER_RESULT:"):
-                result_data = json.loads(line.replace("DAGSTER_RESULT:", ""))
-                context.log.info(f"Prediction summary: {result_data}")
-                return result_data
-        
-        # If no result found, return basic info
-        return {"status": "completed", "duration": duration}
-        
+                return json.loads(line.replace("DAGSTER_RESULT:", ""))
+
+        return {"status": "completed"}
+
     except subprocess.CalledProcessError as e:
-        context.log.error(f"Error running prediction: {e.stderr}")
+        context.log.error(f"Error en scoring: {e.stderr}")
         raise
     finally:
-        # Clean up temporary file
         if os.path.exists(script_path):
             os.unlink(script_path)
 
 
 @asset(
     required_resource_keys={"mlflow_monitoring"},
-    deps=["train_student_dropout_model", "dbt_project_assets"]  # Depends on trained model and DBT data
+    deps=["train_student_dropout_model", "dbt_project_assets"],
 )
 def predict_student_dropout_risk(context: AssetExecutionContext):
     """
-    Generate dropout risk predictions for active students using the latest trained model.
-    
-    This asset:
-    - Loads the latest model from MLflow
-    - Gets active students from marts.student_status where status='estudiando'
-    - Applies the same feature engineering as training
-    - Makes predictions and saves them to predictions.student_dropout_predictions table
-    - Runs in the 'eda-predun' conda environment
-    
-    Returns prediction summary statistics.
+    Genera predicciones de riesgo de abandono para estudiantes activos usando el
+    último modelo registrado en el MLflow Model Registry.
     """
-    
-    # Track the job with MLFlow monitoring
     with context.resources.mlflow_monitoring.track_job(
         job_name="predict_student_dropout_risk",
-        tags={"model_type": "prediction", "environment": "eda-predun"}
+        tags={"environment": "eda-predun"},
     ):
-        context.log.info("Starting student dropout risk prediction")
-        
-        # Run the prediction in conda environment
         result = run_prediction_in_conda_env(context)
-        
-        # Log additional metrics to the MLFlow monitoring resource
         if "total_students" in result:
             context.resources.mlflow_monitoring.log_process_metrics(
                 process_name="model_prediction",
-                start_time=time.time() - result.get("duration", 0),
+                start_time=time.time(),
                 success=True,
                 additional_metrics={
                     "predicted_students": result.get("total_students", 0),
                     "predicted_dropouts": result.get("predicted_dropouts", 0),
-                    "dropout_rate": result.get("dropout_rate", 0),
-                    "avg_dropout_probability": result.get("avg_dropout_probability", 0)
-                }
+                    "dropout_rate":       result.get("dropout_rate", 0),
+                },
             )
-        
-        context.log.info("Student dropout risk prediction completed successfully")
         return result

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -43,6 +43,7 @@ def run_multi_model_training_in_conda_env(context: AssetExecutionContext) -> dic
 import os, time, json, warnings
 import numpy as np
 import pandas as pd
+from sklearn.model_selection import train_test_split
 import mlflow
 import mlflow.sklearn
 from sqlalchemy import create_engine, text
@@ -102,13 +103,13 @@ X_val,   y_val   = X[~train_mask], y[~train_mask]
 # TODO: quitar TRAIN_SAMPLE_FRAC (ponerlo en 1.0) para el run final de la tesis.
 TRAIN_SAMPLE_FRAC = 0.15
 if TRAIN_SAMPLE_FRAC < 1.0:
-    X_train, _, y_train, _ = __import__("sklearn.model_selection", fromlist=["train_test_split"]).train_test_split(
+    X_train, _, y_train, _ = train_test_split(
         X_train, y_train,
         train_size=TRAIN_SAMPLE_FRAC,
         stratify=y_train,
         random_state=42,
     )
-    print(f"Subsampleo aplicado ({TRAIN_SAMPLE_FRAC:.0%}): {{X_train.shape[0]:,}} filas de entrenamiento")
+    print(f"Subsampleo aplicado ({{TRAIN_SAMPLE_FRAC:.0%}}): {{X_train.shape[0]:,}} filas de entrenamiento")
 
 print(f"Train: {{X_train.shape[0]:,}} | Val: {{X_val.shape[0]:,}}")
 

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -378,19 +378,19 @@ print("DAGSTER_RESULT:" + json.dumps(output))
     config_schema={
         "train_sample_frac": Field(
             float,
-            default_value=0.15,
+            default_value=1.0,
             description=(
                 "Fracción del set de entrenamiento a usar. "
-                "0.15 = modo dev (~210K filas, ~2 min). "
-                "1.0 = full run (1.4M filas, ~40-50 min)."
+                "1.0 = full run (1.4M filas, ~40-50 min). "
+                "0.15 = modo dev (~210K filas, ~2 min)."
             ),
         ),
         "n_estimators": Field(
             int,
-            default_value=30,
+            default_value=100,
             description=(
                 "Número de estimadores para GBM y RandomForest. "
-                "30 = modo dev. 100 = full run."
+                "100 = full run. 30 = modo dev (más rápido)."
             ),
         ),
     },

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -96,6 +96,20 @@ train_mask = df["academic_period"] <= TRAIN_CUTOFF
 X_train, y_train = X[train_mask], y[train_mask]
 X_val,   y_val   = X[~train_mask], y[~train_mask]
 
+# ── Subsampleo del training para desarrollo/pruebas ───────────────────────────
+# Con 1.4M filas el entrenamiento es muy lento. Para pruebas usamos el 15%
+# estratificado (≈210K filas), suficiente para comparar modelos.
+# TODO: quitar TRAIN_SAMPLE_FRAC (ponerlo en 1.0) para el run final de la tesis.
+TRAIN_SAMPLE_FRAC = 0.15
+if TRAIN_SAMPLE_FRAC < 1.0:
+    X_train, _, y_train, _ = __import__("sklearn.model_selection", fromlist=["train_test_split"]).train_test_split(
+        X_train, y_train,
+        train_size=TRAIN_SAMPLE_FRAC,
+        stratify=y_train,
+        random_state=42,
+    )
+    print(f"Subsampleo aplicado ({TRAIN_SAMPLE_FRAC:.0%}): {{X_train.shape[0]:,}} filas de entrenamiento")
+
 print(f"Train: {{X_train.shape[0]:,}} | Val: {{X_val.shape[0]:,}}")
 
 # ── Preprocessing pipeline (compartido por todos los modelos) ──────────────────
@@ -115,12 +129,15 @@ def build_pipeline(classifier):
     return Pipeline([("prep", preprocess), ("model", classifier)])
 
 # ── Modelos candidatos ─────────────────────────────────────────────────────────
-# Tres familias distintas: secuencial, paralelo, lineal.
-# Hiperparámetros por defecto + random_state para reproducibilidad.
+# Parámetros reducidos para desarrollo. Para el run final de la tesis,
+# aumentar n_estimators a 100/200 y quitar max_depth.
 model_candidates = [
-    ("GradientBoosting",  GradientBoostingClassifier(random_state=42)),
-    ("RandomForest",      RandomForestClassifier(n_estimators=200, random_state=42, n_jobs=-1)),
-    ("LogisticRegression",LogisticRegression(max_iter=1000, random_state=42, n_jobs=-1)),
+    ("GradientBoosting",   GradientBoostingClassifier(
+        n_estimators=30, max_depth=3, subsample=0.8, random_state=42)),
+    ("RandomForest",       RandomForestClassifier(
+        n_estimators=30, max_depth=8, random_state=42, n_jobs=-1)),
+    ("LogisticRegression", LogisticRegression(
+        max_iter=300, solver="saga", random_state=42, n_jobs=-1)),
 ]
 
 # ── Entrenamiento y evaluación de cada candidato ───────────────────────────────

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -227,12 +227,33 @@ mv = mlflow.register_model(
     model_uri=model_uri,
     name="student_dropout_model",
 )
-# Taggear el run ganador sin reabrirlo — client.set_tag() opera sobre runs cerrados
-client.set_tag(best["run_id"], "winning_model", "true")
-client.set_tag(best["run_id"], "registered_in_registry", "true")
-client.set_tag(best["run_id"], "registry_version", str(mv.version))
+# ── Tagging automático del run ganador (reemplaza tag_mlflow_run.py) ──────────
+# Derivamos staging_periods desde la BD para no hardcodear.
+try:
+    sp_df = pd.read_sql(
+        "SELECT DISTINCT academic_period FROM staging.cursada_historica_raw ORDER BY 1",
+        engine,
+    )
+    staging_periods = sp_df["academic_period"].tolist()
+except Exception:
+    staging_periods = [cycle_period]
+
+version_label = f"v{{mv.version}} — datos hasta {{cycle_period.replace('_', '-')}}"
+
+client.set_tag(best["run_id"], "winning_model",         "true")
+client.set_tag(best["run_id"], "registered_in_registry","true")
+client.set_tag(best["run_id"], "registry_version",      str(mv.version))
+client.set_tag(best["run_id"], "data_version",          cycle_period)
+client.set_tag(best["run_id"], "thesis_run",            "true")
+client.set_tag(best["run_id"], "staging_periods",       ",".join(staging_periods))
+client.set_tag(best["run_id"], "n_staging_periods",     str(len(staging_periods)))
+client.set_tag(best["run_id"], "version_label",         version_label)
+
+client.set_model_version_tag("student_dropout_model", str(mv.version), "data_version", cycle_period)
+client.set_model_version_tag("student_dropout_model", str(mv.version), "thesis_run",   "true")
 
 print(f"  Registrado como student_dropout_model v{{mv.version}}")
+print(f"  Tags automáticos: data_version={{cycle_period}}, staging_periods={{staging_periods}}")
 
 # ── Persistir comparación en PostgreSQL ───────────────────────────────────────
 from datetime import datetime

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -209,12 +209,10 @@ mv = mlflow.register_model(
     model_uri=model_uri,
     name="student_dropout_model",
 )
-mlflow.set_tag("winning_model", "true")  # tag adicional en el run ganador
-
-# Taggear el run ganador en MLflow para identificación visual
-with mlflow.start_run(run_id=best["run_id"]):
-    mlflow.set_tag("registered_in_registry", "true")
-    mlflow.set_tag("registry_version", mv.version)
+# Taggear el run ganador sin reabrirlo — client.set_tag() opera sobre runs cerrados
+client.set_tag(best["run_id"], "winning_model", "true")
+client.set_tag(best["run_id"], "registered_in_registry", "true")
+client.set_tag(best["run_id"], "registry_version", str(mv.version))
 
 print(f"  Registrado como student_dropout_model v{{mv.version}}")
 

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -22,7 +22,7 @@ import tempfile
 import json
 import logging
 
-from dagster import asset, AssetExecutionContext
+from dagster import asset, AssetExecutionContext, Field
 
 
 def _conda_bin() -> str:
@@ -31,9 +31,17 @@ def _conda_bin() -> str:
 
 # ── Script de entrenamiento multi-modelo ──────────────────────────────────────
 
-def run_multi_model_training_in_conda_env(context: AssetExecutionContext) -> dict:
+def run_multi_model_training_in_conda_env(
+    context: AssetExecutionContext,
+    train_sample_frac: float,
+    n_estimators: int,
+) -> dict:
     """
     Ejecuta el entrenamiento de los 3 modelos candidatos en el entorno eda-predun.
+
+    Args:
+        train_sample_frac: fracción del set de entrenamiento a usar (1.0 = datos completos).
+        n_estimators:      número de estimadores para GBM y RandomForest.
 
     Retorna un dict con el nombre del modelo ganador, su AUC y el run_id de MLflow.
     """
@@ -97,11 +105,8 @@ train_mask = df["academic_period"] <= TRAIN_CUTOFF
 X_train, y_train = X[train_mask], y[train_mask]
 X_val,   y_val   = X[~train_mask], y[~train_mask]
 
-# ── Subsampleo del training para desarrollo/pruebas ───────────────────────────
-# Con 1.4M filas el entrenamiento es muy lento. Para pruebas usamos el 15%
-# estratificado (≈210K filas), suficiente para comparar modelos.
-# TODO: quitar TRAIN_SAMPLE_FRAC (ponerlo en 1.0) para el run final de la tesis.
-TRAIN_SAMPLE_FRAC = 0.15
+# ── Subsampleo del training (configurable desde Dagster) ──────────────────────
+TRAIN_SAMPLE_FRAC = {train_sample_frac}
 if TRAIN_SAMPLE_FRAC < 1.0:
     X_train, _, y_train, _ = train_test_split(
         X_train, y_train,
@@ -129,14 +134,12 @@ def build_pipeline(classifier):
     ])
     return Pipeline([("prep", preprocess), ("model", classifier)])
 
-# ── Modelos candidatos ─────────────────────────────────────────────────────────
-# Parámetros reducidos para desarrollo. Para el run final de la tesis,
-# aumentar n_estimators a 100/200 y quitar max_depth.
+# ── Modelos candidatos (n_estimators configurable desde Dagster) ───────────────
 model_candidates = [
     ("GradientBoosting",   GradientBoostingClassifier(
-        n_estimators=30, max_depth=3, subsample=0.8, random_state=42)),
+        n_estimators={n_estimators}, max_depth=3, subsample=0.8, random_state=42)),
     ("RandomForest",       RandomForestClassifier(
-        n_estimators=30, max_depth=8, random_state=42, n_jobs=-1)),
+        n_estimators={n_estimators}, max_depth=8, random_state=42, n_jobs=-1)),
     ("LogisticRegression", LogisticRegression(
         max_iter=300, solver="saga", random_state=42, n_jobs=-1)),
 ]
@@ -372,6 +375,25 @@ print("DAGSTER_RESULT:" + json.dumps(output))
 # ── Asset de entrenamiento ────────────────────────────────────────────────────
 
 @asset(
+    config_schema={
+        "train_sample_frac": Field(
+            float,
+            default_value=0.15,
+            description=(
+                "Fracción del set de entrenamiento a usar. "
+                "0.15 = modo dev (~210K filas, ~2 min). "
+                "1.0 = full run (1.4M filas, ~40-50 min)."
+            ),
+        ),
+        "n_estimators": Field(
+            int,
+            default_value=30,
+            description=(
+                "Número de estimadores para GBM y RandomForest. "
+                "30 = modo dev. 100 = full run."
+            ),
+        ),
+    },
     required_resource_keys={"mlflow_monitoring"},
     deps=["dbt_project_assets"],
 )
@@ -380,13 +402,33 @@ def train_student_dropout_model(context: AssetExecutionContext):
     Entrena 3 modelos candidatos (GradientBoosting, RandomForest, LogisticRegression),
     los evalúa sobre el mismo set de validación, registra el mejor en el MLflow
     Model Registry y persiste la comparación en predictions.model_evaluations.
+
+    Configuración (pasada desde la UI de Dagster o YAML de job):
+        train_sample_frac: fracción de datos de entrenamiento (default 0.15)
+        n_estimators:      estimadores para GBM y RF (default 30)
     """
+    train_sample_frac = context.op_config["train_sample_frac"]
+    n_estimators      = context.op_config["n_estimators"]
+
+    context.log.info(
+        f"Config: train_sample_frac={train_sample_frac}, n_estimators={n_estimators}"
+    )
+
     with context.resources.mlflow_monitoring.track_job(
         job_name="train_student_dropout_model",
-        tags={"environment": "eda-predun", "mode": "multi_model"},
+        tags={
+            "environment":       "eda-predun",
+            "mode":              "multi_model",
+            "train_sample_frac": str(train_sample_frac),
+            "n_estimators":      str(n_estimators),
+        },
     ):
         context.log.info("Iniciando entrenamiento multi-modelo")
-        result = run_multi_model_training_in_conda_env(context)
+        result = run_multi_model_training_in_conda_env(
+            context,
+            train_sample_frac=train_sample_frac,
+            n_estimators=n_estimators,
+        )
 
         if "roc_auc" in result:
             context.resources.mlflow_monitoring.log_process_metrics(

--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -230,6 +230,9 @@ mv = mlflow.register_model(
     model_uri=model_uri,
     name="student_dropout_model",
 )
+# cycle_period definido aquí para que esté disponible en el tagging y en PostgreSQL
+cycle_period = str(df["academic_period"].max())
+
 # ── Tagging automático del run ganador (reemplaza tag_mlflow_run.py) ──────────
 # Derivamos staging_periods desde la BD para no hardcodear.
 try:
@@ -282,9 +285,6 @@ CREATE TABLE IF NOT EXISTS predictions.model_evaluations (
     PRIMARY KEY (cycle_period, model_name)
 )
 """
-
-# Usamos el período más reciente del panel como identificador del ciclo
-cycle_period = str(df["academic_period"].max())
 
 with engine.connect() as conn:
     conn.execute(text(create_schema_sql))

--- a/predun_dagster/predun_dagster/definitions.py
+++ b/predun_dagster/predun_dagster/definitions.py
@@ -5,6 +5,7 @@ import datetime
 
 from .assets import (
     dbt_project_assets,
+    detect_data_drift,
     train_student_dropout_model,
     predict_student_dropout_risk,
     format_history_data,
@@ -14,7 +15,7 @@ from .assets import (
 )
 from .resources import PostgresResource, MLflowResource
 from .monitoring import MLFlowMonitoringResource
-from .jobs import refresh_canonical, complete_ml_pipeline
+from .jobs import refresh_canonical, complete_ml_pipeline, drift_job, full_cycle_job
 from .jobs_ingestion import format_data_job, ingest_to_staging_job
 from .sensors import new_period_sensor
 from .constants import PG_URI_ENV, DBT_PROJECT_DIR, DBT_PROFILES_DIR
@@ -56,6 +57,7 @@ dbt_resource = DbtCliResource(
 defs = Definitions(
     assets=[
         dbt_project_assets,
+        detect_data_drift,
         train_student_dropout_model,
         predict_student_dropout_risk,
         format_history_data,
@@ -70,8 +72,10 @@ defs = Definitions(
         "mlflow_monitoring": mlflow_monitoring,
     },
     jobs=[
-        refresh_canonical, 
-        complete_ml_pipeline, 
+        refresh_canonical,
+        complete_ml_pipeline,
+        drift_job,
+        full_cycle_job,
         format_data_job,
         ingest_to_staging_job,
     ],

--- a/predun_dagster/predun_dagster/definitions.py
+++ b/predun_dagster/predun_dagster/definitions.py
@@ -15,7 +15,7 @@ from .assets import (
 )
 from .resources import PostgresResource, MLflowResource
 from .monitoring import MLFlowMonitoringResource
-from .jobs import refresh_canonical, complete_ml_pipeline, drift_job, full_cycle_job
+from .jobs import refresh_canonical, complete_ml_pipeline, drift_job, drift_train_predict
 from .jobs_ingestion import format_data_job, ingest_to_staging_job
 from .sensors import new_period_sensor
 from .constants import PG_URI_ENV, DBT_PROJECT_DIR, DBT_PROFILES_DIR
@@ -75,7 +75,7 @@ defs = Definitions(
         refresh_canonical,
         complete_ml_pipeline,
         drift_job,
-        full_cycle_job,
+        drift_train_predict,
         format_data_job,
         ingest_to_staging_job,
     ],

--- a/predun_dagster/predun_dagster/drift_utils.py
+++ b/predun_dagster/predun_dagster/drift_utils.py
@@ -1,0 +1,271 @@
+"""
+Utilidades de detección de drift para PREDUN.
+
+Implementa PSI (Population Stability Index) para features continuas y categóricas.
+Módulo de funciones puras: sin dependencias de Dagster ni MLflow, completamente testeable.
+
+Umbrales PSI (estándar de la literatura de riesgo financiero y MLOps):
+  PSI < 0.10  : sin cambio significativo — reentrenamiento rutinario
+  0.10 – 0.25 : cambio moderado         — monitorear, aumentar frecuencia de reentrenamiento
+  PSI > 0.25  : cambio severo           — revisar modelo y posiblemente arquitectura
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from typing import Dict, List, Optional, Tuple
+
+# ── Constantes ────────────────────────────────────────────────────────────────
+
+PSI_THRESHOLD_LOW  = 0.10   # sin drift significativo
+PSI_THRESHOLD_HIGH = 0.25   # drift severo
+N_BINS_DEFAULT     = 10     # bins para variables continuas
+EPSILON            = 1e-6   # evitar log(0) y división por cero
+
+# Features a analizar para drift (excluye materias_cum porque es acumulativa por
+# definición y siempre deriva, y cod_carrera que está acotado a 29 carreras estables)
+FEATURES_NUM = [
+    "materias_en_periodo",
+    "promo_en_periodo",
+    "nota_media_en_periodo",
+    "materias_win3",
+    "promo_win3",
+    "nota_win3",
+    "dias_desde_ult_periodo",
+    "promo_rate_period",
+    "promo_rate_win3",
+]
+FEATURES_CAT = ["cod_carrera"]
+LABEL_COL    = "dropout_next"
+
+# Corte de entrenamiento — mismo que en ml_assets.py
+TRAIN_CUTOFF = "2022_2C"
+
+
+# ── Funciones de PSI ──────────────────────────────────────────────────────────
+
+def drift_level(psi: float) -> str:
+    """Convierte valor PSI al nivel de drift semántico."""
+    if psi < PSI_THRESHOLD_LOW:
+        return "none"
+    elif psi < PSI_THRESHOLD_HIGH:
+        return "moderate"
+    else:
+        return "high"
+
+
+def psi_continuous(
+    reference: pd.Series,
+    current: pd.Series,
+    n_bins: int = N_BINS_DEFAULT,
+) -> Tuple[float, pd.DataFrame]:
+    """
+    Calcula PSI entre dos distribuciones continuas.
+
+    Los bins se definen por percentiles de la distribución de referencia,
+    lo que garantiza que cada bin tenga aproximadamente la misma densidad
+    en la referencia y hace al índice comparable entre features.
+
+    Returns:
+        psi_value: índice PSI agregado
+        bin_df: detalle por bin (útil para diagnóstico)
+    """
+    ref = reference.dropna()
+    cur = current.dropna()
+
+    if len(ref) == 0 or len(cur) == 0:
+        return 0.0, pd.DataFrame()
+
+    # Bins por percentiles de la referencia
+    edges = np.percentile(ref, np.linspace(0, 100, n_bins + 1))
+    edges[0]  -= EPSILON
+    edges[-1] += EPSILON
+    edges = np.unique(edges)
+
+    if len(edges) < 3:  # distribución degenerada (p.ej. constante)
+        return 0.0, pd.DataFrame()
+
+    ref_counts, _ = np.histogram(ref, bins=edges)
+    cur_counts, _ = np.histogram(cur, bins=edges)
+
+    ref_pct = np.where(ref_counts == 0, EPSILON, ref_counts / len(ref))
+    cur_pct = np.where(cur_counts == 0, EPSILON, cur_counts / len(cur))
+
+    contributions = (cur_pct - ref_pct) * np.log(cur_pct / ref_pct)
+    psi_value = float(np.sum(contributions))
+
+    bin_df = pd.DataFrame({
+        "bin_low":      edges[:-1],
+        "bin_high":     edges[1:],
+        "ref_count":    ref_counts,
+        "cur_count":    cur_counts,
+        "ref_pct":      ref_pct,
+        "cur_pct":      cur_pct,
+        "psi_bin":      contributions,
+    })
+
+    return psi_value, bin_df
+
+
+def psi_categorical(
+    reference: pd.Series,
+    current: pd.Series,
+) -> float:
+    """
+    Calcula PSI para una variable categórica.
+
+    Itera sobre la unión de categorías presentes en referencia y actual.
+    Categorías nuevas (no vistas en referencia) contribuyen con su peso completo.
+    """
+    ref = reference.dropna()
+    cur = current.dropna()
+
+    if len(ref) == 0 or len(cur) == 0:
+        return 0.0
+
+    all_cats = set(ref.unique()) | set(cur.unique())
+    ref_vc = ref.value_counts()
+    cur_vc = cur.value_counts()
+
+    psi_value = 0.0
+    for cat in all_cats:
+        r = max(ref_vc.get(cat, 0) / len(ref), EPSILON)
+        c = max(cur_vc.get(cat, 0) / len(cur), EPSILON)
+        psi_value += (c - r) * np.log(c / r)
+
+    return float(psi_value)
+
+
+# ── Función principal de análisis de drift ────────────────────────────────────
+
+def compute_feature_drift(
+    df_reference: pd.DataFrame,
+    df_current: pd.DataFrame,
+    features_num: Optional[List[str]] = None,
+    features_cat: Optional[List[str]] = None,
+    include_label: bool = True,
+) -> pd.DataFrame:
+    """
+    Calcula PSI para todas las features entre referencia y conjunto actual.
+
+    Args:
+        df_reference: datos de referencia (distribución base — típicamente training set)
+        df_current:   datos actuales (distribución a evaluar — nuevos datos o scoring set)
+        features_num: lista de features continuas a analizar
+        features_cat: lista de features categóricas a analizar
+        include_label: si True, incluye PSI de la variable objetivo (label drift)
+
+    Returns:
+        DataFrame con columnas:
+            feature_name, feature_type, psi_value, drift_level,
+            mean_reference, mean_current, n_reference, n_current
+        Ordenado por psi_value descendente.
+    """
+    num_cols = features_num if features_num is not None else FEATURES_NUM
+    cat_cols = features_cat if features_cat is not None else FEATURES_CAT
+
+    rows = []
+
+    for col in num_cols:
+        if col not in df_reference.columns or col not in df_current.columns:
+            continue
+        psi, _ = psi_continuous(df_reference[col], df_current[col])
+        rows.append({
+            "feature_name":   col,
+            "feature_type":   "numeric",
+            "psi_value":      round(psi, 6),
+            "drift_level":    drift_level(psi),
+            "mean_reference": _safe_mean(df_reference[col]),
+            "mean_current":   _safe_mean(df_current[col]),
+            "n_reference":    int(df_reference[col].notna().sum()),
+            "n_current":      int(df_current[col].notna().sum()),
+        })
+
+    for col in cat_cols:
+        if col not in df_reference.columns or col not in df_current.columns:
+            continue
+        psi = psi_categorical(df_reference[col], df_current[col])
+        rows.append({
+            "feature_name":   col,
+            "feature_type":   "categorical",
+            "psi_value":      round(psi, 6),
+            "drift_level":    drift_level(psi),
+            "mean_reference": None,
+            "mean_current":   None,
+            "n_reference":    int(df_reference[col].notna().sum()),
+            "n_current":      int(df_current[col].notna().sum()),
+        })
+
+    if include_label and LABEL_COL in df_reference.columns and LABEL_COL in df_current.columns:
+        # Label drift: compara distribución de dropout_next (binario → trato como categórico)
+        psi = psi_categorical(
+            df_reference[LABEL_COL].astype(str),
+            df_current[LABEL_COL].astype(str),
+        )
+        rows.append({
+            "feature_name":   LABEL_COL,
+            "feature_type":   "label",
+            "psi_value":      round(psi, 6),
+            "drift_level":    drift_level(psi),
+            "mean_reference": _safe_mean(df_reference[LABEL_COL]),
+            "mean_current":   _safe_mean(df_current[LABEL_COL]),
+            "n_reference":    int(df_reference[LABEL_COL].notna().sum()),
+            "n_current":      int(df_current[LABEL_COL].notna().sum()),
+        })
+
+    df_drift = pd.DataFrame(rows)
+    if not df_drift.empty:
+        df_drift = df_drift.sort_values("psi_value", ascending=False).reset_index(drop=True)
+
+    return df_drift
+
+
+def drift_summary(df_drift: pd.DataFrame) -> Dict:
+    """
+    Resume los resultados de drift en un dict serializable.
+
+    Retorna el nivel de drift global (el peor feature determina el nivel),
+    conteos por nivel, y el top-3 de features con mayor PSI.
+    """
+    if df_drift.empty:
+        return {"overall_level": "unknown", "max_psi": 0.0, "n_features": 0}
+
+    max_psi  = float(df_drift["psi_value"].max())
+    n_high   = int((df_drift["drift_level"] == "high").sum())
+    n_mod    = int((df_drift["drift_level"] == "moderate").sum())
+    n_none   = int((df_drift["drift_level"] == "none").sum())
+
+    if n_high > 0:
+        overall = "high"
+    elif n_mod > 0:
+        overall = "moderate"
+    else:
+        overall = "none"
+
+    top3 = (
+        df_drift[["feature_name", "psi_value", "drift_level"]]
+        .head(3)
+        .to_dict(orient="records")
+    )
+
+    return {
+        "overall_level":   overall,
+        "max_psi":         round(max_psi, 6),
+        "n_features_high": n_high,
+        "n_features_mod":  n_mod,
+        "n_features_none": n_none,
+        "n_features":      len(df_drift),
+        "top3_features":   top3,
+    }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _safe_mean(series: pd.Series) -> Optional[float]:
+    valid = series.dropna()
+    if len(valid) == 0:
+        return None
+    try:
+        return float(valid.mean())
+    except (TypeError, ValueError):
+        return None

--- a/predun_dagster/predun_dagster/jobs.py
+++ b/predun_dagster/predun_dagster/jobs.py
@@ -11,7 +11,28 @@ refresh_canonical = define_asset_job(
     ),
 )
 
+# Entrenamiento multi-modelo + scoring (sin detección de drift)
 complete_ml_pipeline = define_asset_job(
     name="complete_ml_pipeline",
-    selection=AssetSelection.assets("train_student_dropout_model", "predict_student_dropout_risk"),
+    selection=AssetSelection.assets(
+        "train_student_dropout_model",
+        "predict_student_dropout_risk",
+    ),
+)
+
+# Solo detección de drift (ejecutar luego de refresh_canonical)
+drift_job = define_asset_job(
+    name="drift_job",
+    selection=AssetSelection.assets("detect_data_drift"),
+)
+
+# Ciclo completo de ML: drift → entrenamiento multi-modelo → scoring
+# Ejecutar luego de refresh_canonical para tener student_panel actualizado.
+full_cycle_job = define_asset_job(
+    name="full_cycle_job",
+    selection=AssetSelection.assets(
+        "detect_data_drift",
+        "train_student_dropout_model",
+        "predict_student_dropout_risk",
+    ),
 )

--- a/predun_dagster/predun_dagster/jobs.py
+++ b/predun_dagster/predun_dagster/jobs.py
@@ -28,8 +28,8 @@ drift_job = define_asset_job(
 
 # Ciclo completo de ML: drift → entrenamiento multi-modelo → scoring
 # Ejecutar luego de refresh_canonical para tener student_panel actualizado.
-full_cycle_job = define_asset_job(
-    name="full_cycle_job",
+drift_train_predict = define_asset_job(
+    name="drift_train_predict",
     selection=AssetSelection.assets(
         "detect_data_drift",
         "train_student_dropout_model",


### PR DESCRIPTION
- drift_utils.py: pure PSI functions (continuous + categorical) with standard thresholds (none/moderate/high). Fully testable, no framework deps.

- assets/drift_assets.py: new Dagster asset detect_data_drift that compares training distribution (<=2022_2C) vs new data using PSI per feature. Logs metrics to MLflow experiment 'drift_monitoring' and persists results to predictions.drift_metrics table for Superset visualization.

- assets/ml_assets.py: refactored training to run 3 model candidates (GradientBoosting, RandomForest, LogisticRegression) in one pipeline run. Each candidate gets its own tagged MLflow run; the winner by AUC is registered in the Model Registry. Comparison saved to predictions.model_evaluations for Superset dashboards.

- jobs.py: added drift_job (drift only) and full_cycle_job (drift + train + predict) as first-class Dagster jobs.

New PostgreSQL tables created on first run:
  predictions.drift_metrics      — PSI per feature per cycle
  predictions.model_evaluations  — model comparison per cycle