### PR TITLE
Fix training-serving skew in scoring row selection

### DIFF
--- a/predun_dagster/predun_dagster/assets/ml_assets.py
+++ b/predun_dagster/predun_dagster/assets/ml_assets.py
@@ -577,7 +577,15 @@ if len(student_panel) == 0:
     print("Sin datos de panel para activos — saliendo")
     exit(0)
 
-df = student_panel.groupby("legajo").first().reset_index()
+# Fila más reciente por legajo (la consulta ya ordena por academic_period DESC).
+# NO usar groupby(...).first(): devuelve el primer valor NO NULO de cada columna por
+# separado, no la primera fila. Como nota_media_en_periodo, nota_win3, promo_rate_period
+# y promo_rate_win3 son NULL cuando el estudiante no cursó en el período, .first() las
+# rellenaba con valores de períodos anteriores y armaba una fila híbrida (conteos del
+# período reciente + notas/tasas de períodos viejos). En entrenamiento esos NULL llegan
+# como NaN al SimpleImputer, así que el scoring aplicaba una transformación distinta:
+# training-serving skew. Ver issue #5.
+df = student_panel.groupby("legajo", sort=False).head(1).reset_index(drop=True)
 print(f"{{len(df)}} registros más recientes para scoring")
 
 NUM_COLS = [


### PR DESCRIPTION
Fixes the training-serving skew reported in #5.

## The problem

`predict_student_dropout_risk` selected each student's most recent panel row with `groupby("legajo").first()`. That method returns the first **non-null value of each column independently**, not the group's first row.

The only nullable columns in `marts.student_panel` are `nota_media_en_periodo`, `nota_win3`, `promo_rate_period` and `promo_rate_win3` — null precisely when the student took no courses in that period. So `.first()` backfilled them from earlier periods and produced a hybrid row: counts and `academic_period` from the most recent period, grades and rates from older ones.

Training (`ml_assets.py:130`) reads the panel with no `groupby`, so those nulls reach `SimpleImputer(strategy="median")`. Scoring was applying a different transformation to the same features.

## The change

```diff
-df = student_panel.groupby("legajo").first().reset_index()
+df = student_panel.groupby("legajo", sort=False).head(1).reset_index(drop=True)
```

`.head(1)` takes the actual first row of each group, which the query's `ORDER BY legajo, academic_period DESC` already guarantees is the most recent one. A comment was added so the trap is not reintroduced. This was the only occurrence of the pattern in the repository.

## Verification

The scoring code lives inside an f-string template, so the generated script was extracted and compiled first. The row-selection logic was then run against the database with model v58 (the one that produced the currently persisted predictions):

| check | result |
|---|---|
| scored cohort | 19,927 (unchanged) |
| `academic_period` per legajo | unchanged, and equal to `max(academic_period)` |
| nulls restored | `nota_media_en_periodo` 3,390 -> 11,213; `promo_rate_period` 1 -> 7,540 |
| mean probability | 0.3385 -> 0.3862 |
| positives at 0.5 threshold | 6,687 -> 7,625 |
| NaN after preprocessing | 0 (the imputer now fires, as in training) |

These match the values predicted in #5. No writes to the database and no servers started during verification.

## Scope

Scoring only. Training, backtesting, evaluation metrics (AUC, Brier, KS, Precision@K) and drift detection are unaffected — none of those paths use `groupby`, so the reported model metrics remain valid.

## Follow-up (not in this PR)

The predictions already stored in `predictions.student_dropout_predictions` were produced by the faulty path and need to be regenerated with `drift_train_predict`. That is why the commit says `Refs #5` rather than `Closes #5`.
